### PR TITLE
Bump minimum CMake version in order to support CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 3.6) 
 project (JDKSMIDI)
 
 include_directories( ${JDKSMIDI_SOURCE_DIR}/include )


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features